### PR TITLE
Removed root_url setting of grafana

### DIFF
--- a/integration/grafana/override_values.yaml
+++ b/integration/grafana/override_values.yaml
@@ -3237,6 +3237,3 @@ grafana.ini:
     headers: ""
      # Check out docs on this for more details on the below setting
     enable_login_token: false
-
-  server:
-    root_url: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"


### PR DESCRIPTION
With the root_url setting, it will result in an error page showing "If you're seeing this Grafana has failed to load its application files" when visit the Cost Report  refering to https://github.com/gocrane/crane

AFAIK，by referring with https://grafana.com/docs/grafana/latest/administration/configuration/,   the root_url setting is usually used with grafana deployment behind reverse proxy or using Google or GitHub OAuth authentication (for the callback URL to be correct).  