### PR TITLE
Add finalizers role for node and tsp

### DIFF
--- a/charts/crane/templates/crane-agent-rbac.yaml
+++ b/charts/crane/templates/crane-agent-rbac.yaml
@@ -39,6 +39,7 @@ rules:
     resources:
       - nodes
       - nodes/status
+      - nodes/finalizers
     verbs:
       - get
       - list
@@ -79,6 +80,7 @@ rules:
       - "prediction.crane.io"
     resources:
       - timeseriespredictions
+      - timeseriespredictions/finalizers
     verbs:
       - get
       - list


### PR DESCRIPTION
Users may use OwnerReferencesPermissionEnforcement plugin, so add finalizers role for node and tsp to role