### PR TITLE
fix regrex error in prometheus overrides

### DIFF
--- a/integration/prometheus/override_values.yaml
+++ b/integration/prometheus/override_values.yaml
@@ -75,7 +75,20 @@ extraScrapeConfigs: |-
       regex: ([^:]+)(?::\d+)?
       replacement: "${1}:8080"
       target_label: __address__
-
+  - job_name: crane-agent
+    kubernetes_sd_configs:
+    - role: pod
+    relabel_configs:
+    - action: keep
+      regex: crane-system;crane-agent-(.+)
+      source_labels:
+      - __meta_kubernetes_namespace
+      - __meta_kubernetes_pod_name
+    - source_labels:
+      - __address__
+      regex: ([^:]+)(?::\d+)?
+      replacement: "${1}:8081"
+      target_label: __address__
 server:
   service:
     annotations: { }

--- a/integration/prometheus/override_values.yaml
+++ b/integration/prometheus/override_values.yaml
@@ -72,7 +72,7 @@ extraScrapeConfigs: |-
       - __meta_kubernetes_pod_name
     - source_labels:
       - __address__
-      regex: (.*)
+      regex: ([^:]+)(?::\d+)?
       replacement: "${1}:8080"
       target_label: __address__
 


### PR DESCRIPTION
regex is incorrect so it did not cut the original containerPod and the replacement action append another port at the end, so an invalid target is shown on prometheus.