### PR TITLE
fix: crane chart version bump up to 0.6.1

### DIFF
--- a/charts/crane/Chart.yaml
+++ b/charts/crane/Chart.yaml
@@ -14,8 +14,23 @@ keywords:
 sources:
   - https://github.com/gocrane/crane
 
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 0.6.0
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.6.1
 
-appVersion: v0.6.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.6.0"


### PR DESCRIPTION
The pr #68 changed the content of the Crane repo, but there was no upgrade version, resulting in errors in subsequent ci executions, but I don't know why that merged ci execution did not go wrong. Anyway, I think increasing the crane chart version  can solve this problem.