### PR TITLE
change rules

### DIFF
--- a/integration/prometheus/override_values.yaml
+++ b/integration/prometheus/override_values.yaml
@@ -9,10 +9,10 @@ serverFiles:
         interval: 3600s
         rules:
           - expr: |
-              sum(label_replace(irate(container_cpu_usage_seconds_total{container!="POD", container!="",image!=""}[1h]), "node", "$1", "instance",  "([0-9.]*)")) by (container, pod, node, namespace) * on (node) group_left() avg(avg_over_time(node_cpu_hourly_cost[1h])) by (node)
+              sum(label_replace(irate(container_cpu_usage_seconds_total{container!="POD", container!="",image!=""}[1h]), "node", "$1", "instance",  "(.*)")) by (container, pod, node, namespace) * on (node) group_left() avg(avg_over_time(node_cpu_hourly_cost[1h])) by (node)
             record: namespace:container_cpu_usage_costs_hourly:sum_rate
           - expr: |
-              sum(label_replace(avg_over_time(container_memory_working_set_bytes{container!="POD",container!="",image!=""}[1h]), "node", "$1", "instance",  "([0-9.]*)")) by (container, pod, node, namespace) / 1024.0 / 1024.0 / 1024.0 * on (node) group_left() avg(avg_over_time(node_ram_hourly_cost[1h])) by (node)
+              sum(label_replace(avg_over_time(container_memory_working_set_bytes{container!="POD",container!="",image!=""}[1h]), "node", "$1", "instance",  "(.*)")) by (container, pod, node, namespace) / 1024.0 / 1024.0 / 1024.0 * on (node) group_left() avg(avg_over_time(node_ram_hourly_cost[1h])) by (node)
             record: namespace:container_memory_usage_costs_hourly:sum_rate
           - expr: |
               avg(avg_over_time(node_cpu_hourly_cost[1h])) by (node)


### PR DESCRIPTION
Signed-off-by: liuqx <liuqx@glodon.com>

adjust the prometheus rule to make the compatible host name start with a letter, and fix the problem that the namespace cost distribution on the dashboard is empty.


<img width="592" alt="image" src="https://user-images.githubusercontent.com/30148386/217807498-b87ae930-4690-41d8-9191-9c65f4fc945b.png">
